### PR TITLE
Fix: Align website elements with header logo

### DIFF
--- a/pages/footer.html
+++ b/pages/footer.html
@@ -1,11 +1,11 @@
 <!-- Footer -->
 <footer class="footer">
-    <div class="footer-logos">
-        <img src="../branding/ICC-ES-Logo.png" alt="ICC-ES Certified" title="ICC-ES Certified">
-        <img src="../branding/Made_In_USA_badge@2x.png" alt="Made in USA" title="Made in USA">
-        <img src="../branding/made_in_wisconsin.png" alt="Made in Wisconsin" title="Made in Wisconsin">
-    </div>
     <div class="page-container">
+        <div class="footer-logos">
+            <img src="../branding/ICC-ES-Logo.png" alt="ICC-ES Certified" title="ICC-ES Certified">
+            <img src="../branding/Made_In_USA_badge@2x.png" alt="Made in USA" title="Made in USA">
+            <img src="../branding/made_in_wisconsin.png" alt="Made in Wisconsin" title="Made in Wisconsin">
+        </div>
         <div class="footer-content">
             <div class="footer-column">
                 <h3>About Us</h3>

--- a/styles/mobile.css
+++ b/styles/mobile.css
@@ -178,8 +178,7 @@
 
     /* Footer */
     .footer {
-        padding: 3rem 15px 2rem;
-        margin: 0 -15px;
+        padding: 3rem 20px 2rem; /* Adjusted padding to align with page-container */
     }
 
     .footer-logos {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -885,14 +885,12 @@ header {
 }
 
 .footer-logos {
-    position: absolute;
-    top: 0;
-    right: 0;
-    display: flex;
-    gap: 1rem;
-    padding: 1rem;
-    transform: translateY(-50%);
-    z-index: 10;
+    display: flex; /* Was already flex, kept */
+    justify-content: flex-end; /* Align to the right */
+    align-items: center; /* Vertically align items */
+    gap: 1rem; /* Kept from original */
+    padding: 0; /* Reset padding */
+    margin-bottom: 1rem; /* Space below logos */
 }
 
 .footer-logos img {

--- a/styles/tablet.css
+++ b/styles/tablet.css
@@ -1,7 +1,6 @@
 /* Tablet Styles (max-width: 992px) */
 @media (max-width: 992px) {
     body {
-        padding: 0 20px;
         overflow-x: hidden;
     }
     
@@ -10,10 +9,17 @@
         overflow-x: hidden;
     }
 
+    .navbar {
+        padding: 0 20px;
+        margin: 0 auto;
+        max-width: 1200px;
+        position: relative; /* For positioning child elements */
+    }
+
     .nav-links {
         display: none;
-        position: fixed;
-        top: 80px;
+        position: absolute; /* Changed from fixed */
+        top: 80px; /* Positioned relative to navbar */
         left: 0;
         right: 0;
         background: var(--light-cream);
@@ -23,6 +29,7 @@
         gap: 1rem;
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         transform: none;
+        z-index: 101; /* Ensure it's above other content but below mobile-menu-btn if it overlaps */
     }
 
     .nav-links.active {
@@ -32,11 +39,10 @@
     .mobile-menu-btn {
         display: block;
         position: absolute;
-        right: 20px;
+        right: 0; /* Adjusted relative to navbar */
         top: 50%;
         transform: translateY(-50%);
         z-index: 102;
-        margin-top: 2rem;
     }
 
     .nav-tag {
@@ -44,9 +50,8 @@
     }
 
     .logo {
-        position: fixed;
-        left: 20px;
         width: 180px;
+        margin-left: 0;
         padding: 0.4rem 0 0 0;
     }
 


### PR DESCRIPTION
This commit introduces consistent left and right margins across the website, ensuring that all page elements align with the header logo.

Key changes include:

1.  **Tablet View (`styles/tablet.css`):**
    *   Removed fixed positioning from the website logo, allowing it to scroll naturally and align with centered content.
    *   Ensured the navbar is centered using `margin: 0 auto` and has padding consistent with the overall page container.
    *   Removed direct padding from the `body` element to rely on the `.page-container` class for content padding.
    *   Adjusted mobile menu button and navigation links to correctly position within the centered navbar.

2.  **Mobile View (`styles/mobile.css`):**
    *   Corrected footer alignment by removing negative margins that previously caused it to break out of the main content flow.
    *   Adjusted footer padding to match the mobile `.page-container` padding.

3.  **Footer Structure and Styling (`pages/footer.html`, `styles/styles.css`):**
    *   Relocated the `.footer-logos` div within the main `.page-container` in the footer's HTML structure.
    *   Updated CSS for `.footer-logos` to use flexbox for alignment, removing absolute positioning. This ensures logos align with the centered page content on desktop/tablet and remain centered on mobile.

These changes provide a more unified and visually consistent layout across different screen sizes.